### PR TITLE
Update the name of the plugin in package.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="io.litehelpers.cordova.sqlcipher"
+    id="cordova-sqlcipher-adapter"
     version="0.1.4-rc">
 
     <name>Cordova sqlcipher adapter</name>

--- a/tests/plugin.xml
+++ b/tests/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
-    id="io.liteglue.sqliteStorage.tests"
+    id="cordova-sqlcipher-adapter-tests"
     version="0.0.1">
 
     <name>Cordova sqlite storage tests</name>


### PR DESCRIPTION
In order to have consistent naming of the plugin's `package.json` file and repository name I've updated the name in `package.xml`.

It would be also great if you could register the plugin with NPM. Setting up the plugin in the app's config file would look like:
`<plugin name="cordova-sqlcipher-adapter" spec="~0.14" />`
instead of:
`<plugin name="io.litehelpers.cordova.sqlcipher" spec="https://github.com/litehelpers/Cordova-sqlcipher-adapter" />`

Thank you for this great plugin.
