### PR TITLE
Fix Windows build fails due to incorrect dep references

### DIFF
--- a/src/windows/SQLite3-Win-RT/SQLite3/SQLite3.Shared.vcxitems
+++ b/src/windows/SQLite3-Win-RT/SQLite3/SQLite3.Shared.vcxitems
@@ -27,85 +27,85 @@
     <ClCompile Include="$(MSBuildThisFileDirectory)Constants.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Database.cpp" />
     <ClCompile Include="$(MSBuildThisFileDirectory)Statement.cpp" />
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\common\sqlite3.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\common\sqlite3.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\cbc_encrypt.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\cbc_encrypt.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\cbc_decrypt.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\cbc_decrypt.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\cbc_start.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\cbc_start.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\cbc_done.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\cbc_done.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\crypt_find_cipher.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\crypt_find_cipher.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\crypt_find_hash.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\crypt_find_hash.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\crypt_register_hash.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\crypt_register_hash.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\crypt_register_cipher.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\crypt_register_cipher.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\crypt_register_prng.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\crypt_register_prng.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\crypt_argchk.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\crypt_argchk.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\crypt_cipher_is_valid.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\crypt_cipher_is_valid.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\crypt_cipher_descriptor.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\crypt_cipher_descriptor.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\crypt_prng_descriptor.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\crypt_prng_descriptor.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\crypt_hash_is_valid.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\crypt_hash_is_valid.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\crypt_hash_descriptor.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\crypt_hash_descriptor.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\hash_memory.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\hash_memory.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\zeromem.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\zeromem.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\pkcs_5_2.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\pkcs_5_2.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\aes.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\aes.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\sha1.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\sha1.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\hmac_init.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\hmac_init.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\hmac_memory.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\hmac_memory.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\hmac_process.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\hmac_process.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\hmac_done.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\hmac_done.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\fortuna.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\fortuna.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\..\external\libTomCrypt\sha256.c">
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\libTomCrypt\sha256.c">
       <CompileAsWinRT>false</CompileAsWinRT>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)pch.cpp">


### PR DESCRIPTION
This fixes #32.
